### PR TITLE
Fix pad patch data extractor for slice indexing

### DIFF
--- a/miapy/data/extraction/extractor.py
+++ b/miapy/data/extraction/extractor.py
@@ -305,8 +305,13 @@ class PadPatchDataExtractor(Extractor):
 
         subject_index = params['subject_index']
         index_expr = params['index_expr']  # type: expr.IndexExpression
-        padded_indexing = np.asarray(index_expr.get_indexing()) + self.index_diffs
 
+        # Make sure all indexing is done with slices (Example: (16,) will be changed to (slice(16, 17, None),) which
+        # is equivalent), otherwise the following steps will be wrong; .
+        if any(isinstance(s, int) for s in index_expr.expression):
+            index_expr.set_indexing([slice(s, s + 1) if isinstance(s, int) else s for s in index_expr.expression])
+
+        padded_indexing = np.asarray(index_expr.get_indexing()) + self.index_diffs
         padded_shape = tuple((padded_indexing[:, 1] - padded_indexing[:, 0]).tolist())
 
         sub_indexing = padded_indexing.copy()

--- a/miapy/data/indexexpression.py
+++ b/miapy/data/indexexpression.py
@@ -30,6 +30,8 @@ class IndexExpression:
             elif isinstance(index, (tuple, list)):
                 start, stop = index
                 expr[a] = slice(start, stop)
+            elif isinstance(index, slice):
+                expr[a] = index
             else:
                 raise ValueError('Unknown type "{}" of index'.format(type(index)))
 


### PR DESCRIPTION
I tried to use PadPatchDataExtractor with SliceIndexing which did not work. This should fix it.
I also added an additional case to set_indexing as i would this method to also work with slices.
Detail: Perhaps it would make sense to name it  PadDataExtractor (as it also works with slices)?